### PR TITLE
feat(router): add presentation routing and example pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.1.17",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-router-dom": "^7.10.1",
         "tailwindcss": "^4.1.17"
       },
       "devDependencies": {
@@ -2153,6 +2154,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3421,6 +3435,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.10.1.tgz",
+      "integrity": "sha512-gHL89dRa3kwlUYtRQ+m8NmxGI6CgqN+k4XyGjwcFoQwwCWF6xXpOCUlDovkXClS0d0XJN/5q7kc5W3kiFEd0Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.10.1.tgz",
+      "integrity": "sha512-JNBANI6ChGVjA5bwsUIwJk7LHKmqB4JYnYfzFwyp2t12Izva11elds2jx7Yfoup2zssedntwU0oZ5DEmk5Sdaw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.10.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3522,6 +3574,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tailwindcss/vite": "^4.1.17",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-router-dom": "^7.10.1",
     "tailwindcss": "^4.1.17"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,33 +1,13 @@
+import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from './presentation/providers/ThemeProvider';
+import AppRouter from './presentation/router/Router';
 
 function App() {
   return (
     <ThemeProvider defaultTheme='light'>
-      <div className='flex items-center justify-center phone-frame'>
-        <div className='flex flex-col'>
-          <header className='flex items-center justify-between mb-4'>
-            <div className='w-10 h-10 bg-gray-200 rounded-full' />
-            <div className='text-sm text-gray-500'>
-              Simulación Teléfono — 450px max
-            </div>
-          </header>
-
-          <main className='flex-1 overflow-auto px-2 py-4'>
-            <div className='space-y-3'>
-              <div className='h-4 bg-gray-100 rounded w-3/4' />
-              <div className='h-4 bg-gray-100 rounded w-1/2' />
-              <div className='h-3 bg-gray-100 rounded w-5/6' />
-              <div className='h-40 bg-gradient-to-r from-purple-100 to-pink-100 rounded' />
-            </div>
-          </main>
-
-          <footer className='mt-4 flex justify-center'>
-            <button className='px-[4px] py-2 bg-primary text-white rounded'>
-              Acción
-            </button>
-          </footer>
-        </div>
-      </div>
+      <BrowserRouter>
+        <AppRouter />
+      </BrowserRouter>
     </ThemeProvider>
   );
 }

--- a/src/presentation/pages/Dashboard/Dashboard.tsx
+++ b/src/presentation/pages/Dashboard/Dashboard.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Dashboard = (): React.JSX.Element => {
+  return (
+    <main className='p-4'>
+      <h1 className='text-2xl font-semibold'>Dashboard</h1>
+      <p>Bienvenido al gestor de presupuesto.</p>
+    </main>
+  );
+};
+
+export default Dashboard;

--- a/src/presentation/router/Router.tsx
+++ b/src/presentation/router/Router.tsx
@@ -1,0 +1,17 @@
+import React, { lazy, Suspense } from 'react';
+import { Routes, Route } from 'react-router-dom';
+
+const Dashboard = lazy(() => import('../pages/Dashboard/Dashboard'));
+
+const NotFound: React.FC = () => <div>404 — Página no encontrada</div>;
+
+export default function AppRouter(): React.JSX.Element {
+  return (
+    <Suspense fallback={<div>Cargando...</div>}>
+      <Routes>
+        <Route path='/' element={<Dashboard />} />
+        <Route path='*' element={<NotFound />} />
+      </Routes>
+    </Suspense>
+  );
+}


### PR DESCRIPTION
This pull request introduces React Router to the application, replacing the previous static layout with a routing-based structure. It sets up a basic router with a dashboard page and a fallback for unknown routes, laying the groundwork for scalable navigation in the app.

Routing integration and navigation structure:

* Added `react-router-dom` as a dependency in `package.json` to enable client-side routing.
* Updated `App.tsx` to wrap the application in a `BrowserRouter` and render the new `AppRouter` component, replacing the previous hardcoded layout.
* Created `AppRouter` in `src/presentation/router/Router.tsx`, which defines application routes using `Routes` and `Route`, supports lazy loading for the dashboard, and includes a 404 fallback.

Dashboard page:

* Added a new `Dashboard` page component at `src/presentation/pages/Dashboard/Dashboard.tsx` as the main landing page for the app.